### PR TITLE
Bump gitlab version to 7.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-gitlab_branch: 6-9-stable
-gitlab_shell_version: v1.9.5
+gitlab_branch: 7-0-stable
+gitlab_shell_version: v1.9.6
 
 gitlab_db_type: mysql
 gitlab_db_name: gitlab

--- a/tasks/gitlab.yml
+++ b/tasks/gitlab.yml
@@ -36,7 +36,7 @@
   file: state=link src=/home/{{ gitlab_user }}/tmp dest=/home/{{ gitlab_user }}/gitlab/tmp force=yes
 
 - name: ensure directory for satellites exists
-  file: state=directory path=/home/{{ gitlab_user }}/gitlab-satellites owner={{ gitlab_user }} group={{ gitlab_user }} mode=0700
+  file: state=directory path=/home/{{ gitlab_user }}/gitlab-satellites owner={{ gitlab_user }} group={{ gitlab_user }} mode=0750
 
 - name: ensure directory for repositories exists
   file: state=directory path=/home/{{ gitlab_user }}/repositories owner={{ gitlab_user }} group={{ gitlab_user }} mode=2770


### PR DESCRIPTION
After doing a diff between 6-9-stable and 7-0-stable of the Installation.md, I was able to found the changes in terms of installation. (actually most changes are simply editorial ones).

I've forked your repos and updated the few places where it was impacted.

Note: I cannot test it as my "target" OS is openSUSE. But I don't think my changes break anything that would not have been already broken ;-) my next step will be to try to adapt this to openSUSE...
